### PR TITLE
HEVC support + 8K resolution preset

### DIFF
--- a/RenderMod/Render/EncoderHelpers.cs
+++ b/RenderMod/Render/EncoderHelpers.cs
@@ -26,6 +26,19 @@ namespace RenderMod.Render
 
                 return "libx264";
             }
+            if (ReplayRenderSettings.VideoCodec == "av1")
+            {
+                if (IsEncoderUsable("av1_nvenc", encodersOutput))
+                    return "av1_nvenc";
+
+                if (IsEncoderUsable("av1_amf", encodersOutput))
+                    return "av1_amf";
+
+                if (IsEncoderUsable("av1_qsv", encodersOutput))
+                    return "av1_qsv";
+
+                return "libx264";
+            }
             if (IsEncoderUsable("h264_nvenc", encodersOutput))
                 return "h264_nvenc";
 

--- a/RenderMod/Render/EncoderHelpers.cs
+++ b/RenderMod/Render/EncoderHelpers.cs
@@ -1,6 +1,7 @@
-﻿using IPA.Utilities;
+using IPA.Utilities;
 using System.Diagnostics;
 using System.IO;
+using RenderMod.UI;
 
 namespace RenderMod.Render
 {
@@ -8,11 +9,24 @@ namespace RenderMod.Render
     {
         private static readonly string FFmpegPath =
             Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe");
-
+        
         public static string SelectBestEncoder()
         {
             string encodersOutput = GetEncodersOutput();
 
+            if (ReplayRenderSettings.VideoCodec == "hevc")
+            {
+                if (IsEncoderUsable("hevc_nvenc", encodersOutput))
+                    return "hevc_nvenc";
+
+                if (IsEncoderUsable("hevc_amf", encodersOutput))
+                    return "hevc_amf";
+
+                if (IsEncoderUsable("hevc_qsv", encodersOutput))
+                    return "hevc_qsv";
+
+                return "libx264";
+            }
             if (IsEncoderUsable("h264_nvenc", encodersOutput))
                 return "h264_nvenc";
 

--- a/RenderMod/Render/EncoderHelpers.cs
+++ b/RenderMod/Render/EncoderHelpers.cs
@@ -1,7 +1,6 @@
 using IPA.Utilities;
 using System.Diagnostics;
 using System.IO;
-using RenderMod.UI;
 
 namespace RenderMod.Render
 {

--- a/RenderMod/Render/FfmpegPipe.cs
+++ b/RenderMod/Render/FfmpegPipe.cs
@@ -1,7 +1,8 @@
-﻿using IPA.Utilities;
+using IPA.Utilities;
 using System;
 using System.Diagnostics;
 using System.IO;
+using RenderMod.Render;
 using Debug = UnityEngine.Debug;
 
 public class FFmpegPipe
@@ -94,19 +95,20 @@ public class FFmpegPipe
     }
 
 
-    public static void RemuxRawH264ToMp4(string rawH264Path, string outputMp4Path, int fps)
+    public static void RemuxRawStreamToMp4(string rawStreamPath, string outputMp4Path, int fps)
     {
-        if (!File.Exists(rawH264Path))
+        if (!File.Exists(rawStreamPath))
         {
-            Debug.LogError($"Raw H.264 file not found: {rawH264Path}");
+            Debug.LogError($"Raw video file not found: {rawStreamPath}");
             return;
         }
 
         var ffm = new Process();
         ffm.StartInfo.FileName = Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe");
 
+        string codec = ReplayRenderSettings.VideoCodec;
         ffm.StartInfo.Arguments =
-            $"-y -r {fps} -f h264 -i \"{rawH264Path}\" " +
+            $"-y -r {fps} -f {codec} -i \"{rawStreamPath}\" " +
             $"-c:v copy \"{outputMp4Path}\"";
 
         ffm.StartInfo.UseShellExecute = false;

--- a/RenderMod/Render/ReplayRenderSettings.cs
+++ b/RenderMod/Render/ReplayRenderSettings.cs
@@ -1,4 +1,4 @@
-﻿using IPA.Utilities;
+using IPA.Utilities;
 using System.IO;
 
 namespace RenderMod.Render
@@ -25,10 +25,10 @@ namespace RenderMod.Render
 
         // quality
         public static QualityPreset Preset = QualityPreset.Medium; // default preset
-        public static int BitrateKbps = 8000; // always respected, regardless of preset
+        public static int BitrateKbps = 5000; // always respected, regardless of preset
 
         // encoding
-        public static string VideoCodec = "auto"; // unused (i doubt people have different encoders available)
+        public static string VideoCodec = "h264"; // unused (i doubt people have different encoders available) || AmeRed: let the people choose what they want :)
         public static string PixelFormat = "yuv420p";
         public static bool IncludeAudio = true; // unused, always true for now
         public static string AudioCodec = "aac"; // unused, always aac for now

--- a/RenderMod/Render/ReplayRenderSettings.cs
+++ b/RenderMod/Render/ReplayRenderSettings.cs
@@ -25,7 +25,7 @@ namespace RenderMod.Render
 
         // quality
         public static QualityPreset Preset = QualityPreset.Medium; // default preset
-        public static int BitrateKbps = 5000; // always respected, regardless of preset
+        public static int BitrateKbps = 10000; // always respected, regardless of preset
 
         // encoding
         public static string VideoCodec = "h264"; // unused (i doubt people have different encoders available) || AmeRed: let the people choose what they want :)

--- a/RenderMod/Render/ReplayVideoRenderer.cs
+++ b/RenderMod/Render/ReplayVideoRenderer.cs
@@ -1,4 +1,4 @@
-﻿using RenderMod.Render;
+using RenderMod.Render;
 using RenderMod.Util;
 using SiraUtil.Affinity;
 using SiraUtil.Logging;
@@ -68,12 +68,13 @@ public class ReplayVideoRenderer : ILateDisposable, IAffinity, ILateTickable
 
         var renderRoot = ReplayRenderSettings.RenderRoot;
         Directory.CreateDirectory(Path.Combine(renderRoot, "Unfinished"));
-
+        
+        string codec = ReplayRenderSettings.VideoCodec;
         var timestamp = DateTime.Now.ToString("yyyyMMdd_HHmmss");
         _unfinishedPath = Path.Combine(
             renderRoot,
             "Unfinished",
-            Safe($"replay_{_beatmapLevel.songName}-{_beatmapKey.difficulty}_{timestamp}_video.h264")
+            Safe($"replay_{_beatmapLevel.songName}-{_beatmapKey.difficulty}_{timestamp}_video.{codec}")
         );
 
         _frameBuffers = new byte[BufferCount][];

--- a/RenderMod/UI/RenderSettingsView.bsml
+++ b/RenderMod/UI/RenderSettingsView.bsml
@@ -6,6 +6,9 @@
 					<!-- Preset Dropdown -->
 					<text text="Select a quality level" font-size="4" font-style="Bold" align="Center" color="#FFFFFF"/>
 					<dropdown-list-setting bind-value="true" apply-on-change="true" id='presetDropdown' value='preset-option' options='preset-options' text='Quality' on-change='OnPresetChanged'/>
+					<!-- Video Codec Dropdown -->
+					<text text="Select the video codec" font-size="4" font-style="Bold" align="Center" color="#FFFFFF"/>
+					<dropdown-list-setting bind-value="true" apply-on-change="true" id='videoCodecDropdown' value='video-codec' options='video-codec-options' text='Video Codec' on-change='OnVideoCodecChanged'/>
 					<text id="qualitywarningText" text="" align="Center" active="true" font-size="3" font-color="red" />
 				</vertical>
 			</tab>
@@ -20,12 +23,12 @@
 				<!-- FPS -->
 				<text text="FPS Settings" font-size="4" font-style="Bold" align="Center" color="#FFFFFF"/>
 				<vertical spacing="2" align="Center">
-					<increment-setting bind-value="true" text="Render FPS" id="fps" min="30" max="360" increment="10" integer-only="true" apply-on-change="true" value="fps" on-change="OnFPSChanged"/>
+					<increment-setting bind-value="true" text="Render FPS" id="fps" min="30" max="480" increment="30" integer-only="true" apply-on-change="true" value="fps" on-change="OnFPSChanged"/>
 				</vertical>
 
 				<!-- Bitrate -->
 				<text text="Bitrate Settings" font-size="4" font-style="Bold" align="Center" color="#FFFFFF"/>
-				<increment-setting bind-value="true" text="Video Bitrate (kbps)" id="bitrate" min="1000" max="50000" increment="500" integer-only="true" apply-on-change="true" value="bitrate" on-change="OnBitrateChanged"/>
+				<increment-setting bind-value="true" text="Video Bitrate (kbps)" id="bitrate" min="5000" max="150000" increment="5000" integer-only="true" apply-on-change="true" value="bitrate" on-change="OnBitrateChanged"/>
 				<increment-setting bind-value="true" text="Audio Bitrate (kbps)" id="audioBitrate" min="64" max="320" increment="32" integer-only="true" apply-on-change="true" value="audioBitrate" on-change="OnAudioBitrateChanged"/>
 				<text id="videowarningText" text="" align="Center" active="true" font-size="3" font-color="red" />
 			</vertical>

--- a/RenderMod/UI/RenderSettingsView.cs
+++ b/RenderMod/UI/RenderSettingsView.cs
@@ -1,4 +1,4 @@
-﻿using BeatSaberMarkupLanguage.Attributes;
+using BeatSaberMarkupLanguage.Attributes;
 using BeatSaberMarkupLanguage.Components;
 using BeatSaberMarkupLanguage.Components.Settings;
 using BeatSaberMarkupLanguage.ViewControllers;
@@ -23,7 +23,7 @@ namespace RenderMod.UI
         [UIComponent("videowarningText")] private TMPro.TextMeshProUGUI videoWarningText;
         [UIComponent("camerawarningText")] private TMPro.TextMeshProUGUI cameraWarningText;
         [UIComponent("otherwarningText")] private TMPro.TextMeshProUGUI otherWarningText;
-
+        
         [UIValue("resolution")]
         private string resolution
         {
@@ -37,6 +37,7 @@ namespace RenderMod.UI
                     case 1920 when ReplayRenderSettings.Height == 1080: return "1080p";
                     case 2560 when ReplayRenderSettings.Height == 1440: return "1440p";
                     case 3840 when ReplayRenderSettings.Height == 2160: return "4K";
+                    case 7680 when ReplayRenderSettings.Height == 4320: return "8K";
                     default:
                         _log.Warn($"Unknown resolution setting: {ReplayRenderSettings.Width}x{ReplayRenderSettings.Height}, defaulting to 1080p");
                         return "1080p";
@@ -52,6 +53,7 @@ namespace RenderMod.UI
                     case "1080p": ReplayRenderSettings.Width = 1920; ReplayRenderSettings.Height = 1080; break;
                     case "1440p": ReplayRenderSettings.Width = 2560; ReplayRenderSettings.Height = 1440; break;
                     case "4K": ReplayRenderSettings.Width = 3840; ReplayRenderSettings.Height = 2160; break;
+                    case "8K": ReplayRenderSettings.Width = 7680; ReplayRenderSettings.Height = 4320; break;
                     default:
                         _log.Warn($"Unknown resolution option: {value}, defaulting to 1080p");
                         ReplayRenderSettings.Width = 1920;
@@ -72,13 +74,15 @@ namespace RenderMod.UI
         [UIValue("bitrate")] private int bitrate = ReplayRenderSettings.BitrateKbps;
         [UIValue("audioBitrate")] private int audioBitrate = ReplayRenderSettings.AudioBitrateKbps;
         [UIValue("extraFFmpegArgs")] private string extraFFmpegArgs = ReplayRenderSettings.ExtraFFmpegArgs;
-
+        
+        [UIValue("video-codec-options")] private List<string> videoCodecs = new List<string>() { "h264", "hevc" };
+        [UIValue("video-codec")] private string videoCodec = ReplayRenderSettings.VideoCodec;
         [UIValue("preset-options")] private List<string> presetOptions = new List<string>() { "Low", "Medium", "High" };
         [UIValue("preset-option")] private string currentPreset = ReplayRenderSettings.Preset.ToString();
         [UIValue("resolution-options")]
         private List<string> resolutionOptions = new List<string>()
         {
-            "360p", "480p", "720p", "1080p", "1440p", "4K"
+            "360p", "480p", "720p", "1080p", "1440p", "4K", "8K"
         };
 
         private List<object> _cameraOptions = new List<object>();
@@ -107,13 +111,14 @@ namespace RenderMod.UI
         [UIComponent("cameraType-specifier")] private DropDownListSetting cameraTypeDropDown;
 
         private readonly string FourKWarning = "4K renders require significant processing power and disk space.";
+        private readonly string EightKWarning = "8K renders require the use of a HEVC encoder to render properly.";
         private readonly string FPSWarning = "High FPS values increase file size and CPU usage.";
         private readonly string BitrateWarning = "Bitrates over 10,000 kbps may cause instability or lag.";
         private readonly string ExtraArgsWarning = "Extra FFmpeg arguments can cause instability or crashes.";
         private readonly string PresetWarning = "High Quality preset uses substantial storage and processing.";
         private readonly string NonMainCameraWarning = "Camera is not called \"Main\". Ensure this is the correct camera.";
         private readonly string NoneCameraTypeWarning = "No camera mod installed, main camera will be used.";
-
+        
         [UIAction("OnResolutionChanged")]
         private void OnResolutionChanged(string value)
         {
@@ -184,6 +189,12 @@ namespace RenderMod.UI
                 currentPreset = value;
             }
             UpdateWarnings();
+        }
+        
+        [UIAction("OnVideoCodecChanged")]
+        private void OnVideoCodecChanged(string value)
+        {
+            ReplayRenderSettings.VideoCodec = value;
         }
 
         [UIComponent("encoder-test-text")] private TMPro.TextMeshProUGUI encoderTestText;
@@ -273,6 +284,8 @@ namespace RenderMod.UI
 
             if (currentResolution == "4K")
                 VideoWarnings.Add(FourKWarning);
+            if (currentResolution == "8K")
+                VideoWarnings.Add(EightKWarning);
             if (currentPresetString == QualityPreset.High.ToString())
                 QualityWarnings.Add(PresetWarning);
 

--- a/RenderMod/UI/RenderSettingsView.cs
+++ b/RenderMod/UI/RenderSettingsView.cs
@@ -75,7 +75,7 @@ namespace RenderMod.UI
         [UIValue("audioBitrate")] private int audioBitrate = ReplayRenderSettings.AudioBitrateKbps;
         [UIValue("extraFFmpegArgs")] private string extraFFmpegArgs = ReplayRenderSettings.ExtraFFmpegArgs;
         
-        [UIValue("video-codec-options")] private List<string> videoCodecs = new List<string>() { "h264", "hevc" };
+        [UIValue("video-codec-options")] private List<string> videoCodecs = new List<string>() { "h264", "hevc", "av1" };
         [UIValue("video-codec")] private string videoCodec = ReplayRenderSettings.VideoCodec;
         [UIValue("preset-options")] private List<string> presetOptions = new List<string>() { "Low", "Medium", "High" };
         [UIValue("preset-option")] private string currentPreset = ReplayRenderSettings.Preset.ToString();
@@ -110,12 +110,13 @@ namespace RenderMod.UI
 
         [UIComponent("cameraType-specifier")] private DropDownListSetting cameraTypeDropDown;
 
-        private readonly string FourKWarning = "4K renders require significant processing power and disk space.";
+        private readonly string FourKWarning = "4K/8K renders require significant processing power and disk space.";
         private readonly string EightKWarning = "8K renders require the use of a HEVC encoder to render properly.";
         private readonly string FPSWarning = "High FPS values increase file size and CPU usage.";
         private readonly string BitrateWarning = "Bitrates over 10,000 kbps may cause instability or lag.";
         private readonly string ExtraArgsWarning = "Extra FFmpeg arguments can cause instability or crashes.";
         private readonly string PresetWarning = "High Quality preset uses substantial storage and processing.";
+        private readonly string CodecWarning = "AV1 is chosen as the current codec! You need either an RTX 40 series GPU or an AMD RX 7000 series GPU.";
         private readonly string NonMainCameraWarning = "Camera is not called \"Main\". Ensure this is the correct camera.";
         private readonly string NoneCameraTypeWarning = "No camera mod installed, main camera will be used.";
         
@@ -195,6 +196,7 @@ namespace RenderMod.UI
         private void OnVideoCodecChanged(string value)
         {
             ReplayRenderSettings.VideoCodec = value;
+            UpdateWarnings();
         }
 
         [UIComponent("encoder-test-text")] private TMPro.TextMeshProUGUI encoderTestText;
@@ -279,15 +281,18 @@ namespace RenderMod.UI
             int currentBitrate = ReplayRenderSettings.BitrateKbps;
             string currentExtraArgs = ReplayRenderSettings.ExtraFFmpegArgs;
             string currentPresetString = ReplayRenderSettings.Preset.ToString();
+            string currentCodec = ReplayRenderSettings.VideoCodec;
             string cameraName = ReplayRenderSettings.SpecifiedCameraName;
             string cameraType = ReplayRenderSettings.CameraType;
 
-            if (currentResolution == "4K")
+            if (currentResolution == "4K" || currentResolution == "8K")
                 VideoWarnings.Add(FourKWarning);
             if (currentResolution == "8K")
                 VideoWarnings.Add(EightKWarning);
             if (currentPresetString == QualityPreset.High.ToString())
                 QualityWarnings.Add(PresetWarning);
+            if (currentCodec == "av1")
+                QualityWarnings.Add(CodecWarning);
 
             if (currentFps > 60)
                 VideoWarnings.Add(FPSWarning);


### PR DESCRIPTION
- Added an 8K resolution preset
- Added a special warning for the 8K preset (ie. you need to select HEVC for it to work properly)
- Added a new setting to let people choose what codec they want, with possible expansion (for now its a choice between h264 and HEVC, possibly AV1 in the future for RTX 40 series+ // AMD RX 7000 series+ users)
- Slight tweaks to the Bitrate and FPS increments, Bitrate now has a limit of 150mbps and increments by 5000kbps (5mbps), and FPS now has a limit of 480, and increments by 30  

> (the user is still allowed to mess with their config file for better flexibility, its just that you sometimes get tedious from clicking a button over and over, plus i wanted to allow for more freedom from UI level)

one more thing: can we have the codecs mentioned on readme? i tried to come with something up but its 12am as im making this pr and either way i wouldnt be able to write anything good